### PR TITLE
add D-Bus services for all kwallet versions

### DIFF
--- a/com.thincast.client.json
+++ b/com.thincast.client.json
@@ -19,7 +19,9 @@
         "--filesystem=/run/media",
         "--filesystem=xdg-run/gvfs",
         "--talk-name=com.freedesktop.secrets",
+        "--talk-name=org.kde.kwalletd",
         "--talk-name=org.kde.kwalletd5",
+        "--talk-name=org.kde.kwalletd6",
         "--env=QT_VULKAN_LIB=libvulkan.so.1"
     ],
     "cleanup": [


### PR DESCRIPTION
qtkeychain does support kwallet4 and kwallet6 D-Bus services as well.