### PR TITLE
Fix webcam permissions.

### DIFF
--- a/com.thincast.client.json
+++ b/com.thincast.client.json
@@ -20,6 +20,7 @@
         "--filesystem=/media",
         "--filesystem=/run/media",
         "--filesystem=xdg-run/gvfs",
+        "--filesystem=xdg-run/pipewire-0:ro",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.kde.kwalletd",
         "--talk-name=org.kde.kwalletd5",


### PR DESCRIPTION
With 24.08 runtimes the permissions changed and now also require pipewire read only access.